### PR TITLE
cabal.project: force c2hs to pass -std=gnu18 to GCC

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,6 @@
+
+packages: .
+
+package opendht-hs
+  c2hs-options: -C -std=gnu18
+


### PR DESCRIPTION
This was the default in GCC 14. Since GCC 15, the default is now C23. This makes c2hs break as it was discussed here~[1].

[1]: https://github.com/haskell/c2hs/issues/300